### PR TITLE
Cron reminders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ env/
 .env
 
 tasks.json
+
+/logs

--- a/README.md
+++ b/README.md
@@ -218,6 +218,30 @@ python main.py toggle-email-reminders
 
 ---
 
+### 🕒 Scheduled Email Reminders with Cron (Optional)
+
+To enable daily due-date email `reminders`:
+
+1. Open your systems's crontab:
+
+   ```bash
+   crontab -e
+   ```
+
+   press `i` to enable Insert mode.
+
+2. Add the following line to run daily at 9:00 AM:
+
+   ```bash
+   0 9 * * * /path/to/venv/bin/python /path/to/task-manager-pro/send_reminders.py
+   ```
+
+   Replace `/path/to/venv` and `/path/to/task-manager-pro` with your actual path.
+
+3. Save and exit --> press `esc` and then, `:wq`.
+
+📝 Make sure `.env` is properly configured with Gmail app password support as shown in `.env.template.`
+
 ## 🧰 Developer Notes
 
 - All methods include **type hints**

--- a/send_reminders.py
+++ b/send_reminders.py
@@ -1,0 +1,33 @@
+# send_reminders.py
+import datetime
+from storage.json_storage import JSONStorage
+from utils.emailer import send_email_reminder
+
+storage = JSONStorage("tasks.json")
+data = storage.load_data()
+
+today = datetime.date.today()
+print(f"[{datetime.datetime.now()}] Starting scheduled reminders...\n")
+
+for user_data in data.get("users", []):
+    username = user_data["username"]
+    email = user_data.get("email")
+    reminders_enabled = user_data.get("email_reminders_enabled", False)
+
+    if not email or not reminders_enabled:
+        continue
+
+    due_tasks = [
+        t for t in data.get("tasks", [])
+        if t["user"] == username
+        and not t["completed"]
+        and datetime.datetime.strptime(t["due_date"], "%Y-%m-%d").date() <= today
+    ]
+
+    if due_tasks:
+        subject = "⏰ Daily Task Reminder"
+        body = "\n".join([f"{t['title']} — Due: {t['due_date']}" for t in due_tasks])
+        send_email_reminder(to_email=email, subject=subject, body=body)
+        print(f"[{username}] 🔔 Reminder sent to {email} for {len(due_tasks)} task(s).")
+    else:
+        print(f"[{username}] ✅ No due tasks.")


### PR DESCRIPTION
Added support for automatically sending email reminders to users who have enabled email notifications. This feature uses a scheduled CRON job that runs send_reminders.py daily.

What's included:

1. send_reminders.py for scanning due tasks and emailing users
2. CRON setup instructions added to README.md
3. .gitignore updated to exclude logs and .env
4. Email reminder respects email_reminders_enabled flag per user

